### PR TITLE
Update librewolf.profile: use new D-Bus message bus

### DIFF
--- a/etc/profile-a-l/librewolf.profile
+++ b/etc/profile-a-l/librewolf.profile
@@ -37,7 +37,7 @@ include whitelist-usr-share-common.inc
 #private-etc librewolf
 
 dbus-user filter
-dbus-user.own org.mozilla.librewolf.*
+dbus-user.own io.gitlab.librewolf.*
 # Add the next line to your librewolf.local to enable native notifications.
 #dbus-user.talk org.freedesktop.Notifications
 # Add the next line to your librewolf.local to allow inhibiting screensavers.


### PR DESCRIPTION
Starting Librewolf 96.0, Librewolf switched from using D-Bus `org.mozilla.librewolf.*` to `io.gitlab.librewolf.*` for communicating with open browser sessions.